### PR TITLE
added apt-get line to dependencies

### DIFF
--- a/README
+++ b/README
@@ -47,6 +47,7 @@ It has been tested on Debian, Ubuntu, and ArchLinux.
 
 Get the dependencies:
 
+    sudo apt-get install omake libfuse-dev camlidl libpcre-ocaml-dev libbatteries-ocaml-dev  # Ubuntu
     sudo aptitude install omake libfuse-dev camlidl libpcre-ocaml-dev libbatteries-ocaml-dev  # Debian
     sudo pacman -S omake ocamlfuse-cvs pcre-ocaml ocaml-batteries  # Arch
     sudo yum install fuse-devel ocaml-pcre-devel ocaml-findlib-devel ocaml-camomile ocaml-camlidl ocaml-bisect ocaml-ounit ocaml-ocamldoc  # Fedora


### PR DESCRIPTION
pasting in the aptitude command on ubuntu studio 14.04 caused EVERYTHING to be uninstalled. probably an issue with aptitude/ubuntu studio but still catastrophic for an unsuspecting ubuntu user
